### PR TITLE
fix: use relative path for the main Typescipt file

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+    base: './',
+})


### PR DESCRIPTION
The default of Vite is to use `base: '/'`, which causes all assets to resolve with an absolute path rather than a relative one

Fixes #3
