### PR TITLE
feat: add separate GitHub action for running the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,35 @@
+name: Application Build
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable yarn berry
+        run: corepack enable
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          # Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.
+          cache: yarn
+          # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.
+          cache-dependency-path: yarn.lock
+          # Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.
+          node-version: 22.x
+      - name: Install dependencies
+        run: yarn
+      - name: Run build
+        run: yarn build
+      - name: Upload static files as artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Application Build
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,33 +18,6 @@ permissions:
   id-token: write
 
 jobs:
-  # Build job
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Enable yarn berry
-        run: corepack enable
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4
-        with:
-          # Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.
-          cache: yarn
-          # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.
-          cache-dependency-path: yarn.lock
-          # Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.
-          node-version: 22.x
-      - name: Install dependencies
-        run: yarn
-      - name: Run build
-        run: yarn build
-      - name: Upload static files as artifact
-        id: deployment
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: dist
-
   # Deployment job
   deploy:
     environment:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vanilla",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
In order to help simplify workflows and to increase performance of other workflows, separate the build into its own job. The idea is to then use the artifacts from this job in the other ones to allow them to skip the build process